### PR TITLE
Adapt icon component for a11y

### DIFF
--- a/.changeset/shaggy-donuts-laugh.md
+++ b/.changeset/shaggy-donuts-laugh.md
@@ -1,0 +1,6 @@
+---
+"@siemens/ix-icons": patch
+---
+
+Set aria-hidden for icon svg
+Set "img" role for icon host element

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -104,6 +104,7 @@ export class Icon {
 
     return (
       <Host
+        role="img"
         style={style}
         class={{
           ['size-12']: this.size === '12',
@@ -112,7 +113,7 @@ export class Icon {
           ['size-32']: this.size === '32',
         }}
       >
-        <div class={'svg-container'} innerHTML={this.svgContent}></div>
+        <div class={'svg-container'} innerHTML={this.svgContent} aria-hidden="true"></div>
       </Host>
     );
   }

--- a/src/components/icon/test/ix-icon.spec.tsx
+++ b/src/components/icon/test/ix-icon.spec.tsx
@@ -34,7 +34,7 @@ describe('ix-icon', () => {
       html: `<ix-icon name="${rocket}"></ix-icon>`,
     });
     expect(page.root!.shadowRoot).toEqualHtml(`
-    <div class="svg-container">
+    <div aria-hidden=\"true\" class="svg-container">
       <svg height="512px" version="1.1" viewBox="0 0 512 512" width="512px" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg">
         <g fill="none" fill-rule="evenodd" id="Page-1" stroke="none" stroke-width="1">
           <g id="icon" transform="translate(42.666667, 64.000000)">
@@ -62,7 +62,7 @@ describe('ix-icon', () => {
     });
 
     expect(page.root!.shadowRoot).toEqualHtml(`
-    <div class=\"svg-container\">
+    <div aria-hidden=\"true\" class=\"svg-container\">
       <svg height=\"512\" viewBox=\"0 0 512 512\" width=\"512\" xmlns=\"http://www.w3.org/2000/svg\">
         <path d=\"M384,0 L384,384 L0,384 L0,0 L384,0 Z M192,207.085 L57.751,341.333 L326.248,341.333 L192,207.085 Z M42.666,57.751 L42.666,326.248 L176.915,192 L42.666,57.751 Z M341.333,57.751 L207.085,192 L341.333,326.248 L341.333,57.751 Z M326.248,42.666 L57.751,42.666 L192,176.915 L326.248,42.666 Z\" fill-rule=\"evenodd\" transform=\"translate(64 64)\"></path>
       </svg>


### PR DESCRIPTION
## 💡 What is the current behavior?

Currently the rendered icon is not excluded from screen readers which leads to the icon being part of the a11y tree without any information.

## 🆕 What is the new behavior?

- Icon is hidden from a11y tree
- Icon component now has role "img", so it is detected as an image in the a11y tree and can be described by using aria-label on the host element

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [ ] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [ ] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [ ] 🏗️ Successful compilation (`pnpm build`, changes pushed)
