### PR TITLE
feat(icon): remove prefix of color icon

### DIFF
--- a/.changeset/bright-shirts-roll.md
+++ b/.changeset/bright-shirts-roll.md
@@ -1,0 +1,5 @@
+---
+'@siemens/ix-icons': major
+---
+
+`color` property of the `ix-icon` accepts now any css custom property, previously prefixed with `--theme-`

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -8,7 +8,7 @@ import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 export namespace Components {
     interface IxIcon {
         /**
-          * Color of the icon
+          * Accept only CSS variables as color values e.g. `--si-sys-color-primary`
          */
         "color"?: string;
         /**
@@ -41,7 +41,7 @@ declare global {
 declare namespace LocalJSX {
     interface IxIcon {
         /**
-          * Color of the icon
+          * Accept only CSS variables as color values e.g. `--si-sys-color-primary`
          */
         "color"?: string;
         /**

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -25,7 +25,7 @@ export class Icon {
   @Prop() size: '12' | '16' | '24' | '32' = '24';
 
   /**
-   * Color of the icon
+   * Accept only CSS variables as color values e.g. `--si-sys-color-primary`
    */
   @Prop() color?: string;
 
@@ -99,7 +99,7 @@ export class Icon {
     } = {};
 
     if (this.color) {
-      style['color'] = `var(--theme-${this.color})`;
+      style['color'] = `var(${this.color})`;
     }
 
     return (


### PR DESCRIPTION
<!--
  First off, thanks for taking the time to contribute! ❤️
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->
## 🆕 What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
Due refactoring inside https://github.com/siemens/ix/pull/2632 the color tokens itself will loose the `--theme` prefix.

EIX-229

## 🏁 Checklist

A pull request can only be merged if all of these conditions are met (where applicable):

- [x] 🧪 Unit tests were added/updated and pass (`pnpm test`)
- [x] 📸 Visual regression tests were added/updated and pass ([Guide](https://github.com/siemens/ix/blob/main/CONTRIBUTING.md#visual-regression-testing))
- [x] 🏗️ Successful compilation (`pnpm build`, changes pushed)

## 👨‍💻 Help & support

<!-- If you need help with anything related to your PR please let us know in this section -->
